### PR TITLE
For some reason, the Golang linter in Visual Studio Code removed this…

### DIFF
--- a/cmd/bot/bot.go
+++ b/cmd/bot/bot.go
@@ -17,6 +17,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/bwmarrin/discordgo"
+	"github.com/dustin/go-humanize"
 	redis "gopkg.in/redis.v3"
 )
 


### PR DESCRIPTION
Re-add humanize